### PR TITLE
update the cache model for the fetch calls

### DIFF
--- a/runtimes/nodejs/actions/initialHtml.js
+++ b/runtimes/nodejs/actions/initialHtml.js
@@ -81,7 +81,7 @@ function getHtml(theSignedUrlPut, theSignedUrlGet) {
                   'Access-Control-Allow-Origin': '*',
                   'Access-Control-Allow-Methods': 'GET',
                 },
-                cache: false,
+                cache: 'no-cache',
                 processData: false,
                 contentType: false
             })
@@ -106,7 +106,7 @@ function getHtml(theSignedUrlPut, theSignedUrlGet) {
                   'Access-Control-Allow-Origin': '*',
                   'Access-Control-Allow-Methods': 'PUT',
                 },
-                cache: false,
+                cache: 'no-cache',
                 processData: false,
                 contentType: false
             })


### PR DESCRIPTION
While testing on dev-console (YP) it was discovered that having "false' for the cache property of the "fetch" calls is invalid. 

The valid value that matches "false" is "no-cache". 
